### PR TITLE
Redirect haproxy stderr to docker stdout to catch haproxy startup crashes

### DIFF
--- a/haproxy.rsyslog
+++ b/haproxy.rsyslog
@@ -3,8 +3,13 @@
 # if you experience problems, check:
 # http://www.rsyslog.com/troubleshoot
 
-module(load="imudp")       # UDP listener support
-
+# provides UDP syslog reception
+module(load="imudp")
 input(type="imudp" port="514")
 
-local2.*                                                action(type="omfile" file="/var/log/haproxy.log")
+# change default template to log levels in messages (technically known as priorities)
+$template CustomFormat,"%timegenerated% [%syslogseverity-text%] %syslogtag%%msg:::drop-last-lf%\n"
+$ActionFileDefaultTemplate CustomFormat
+
+# syslog facility used by haproxy
+local2.*    action(type="omfile" file="/var/log/haproxy.log")

--- a/start-simple.sh
+++ b/start-simple.sh
@@ -5,4 +5,4 @@ if [ "${PRINT_CONFIG}" == "enabled" ]; then
     cat /etc/haproxy/haproxy.cfg
 fi
 
-exec haproxy -db -f /etc/haproxy/haproxy.cfg -p /var/run/haproxy.pid
+exec haproxy -q -db -f /etc/haproxy/haproxy.cfg -p /var/run/haproxy.pid

--- a/supervisor.conf
+++ b/supervisor.conf
@@ -1,7 +1,8 @@
 [program:haproxy]
 command=/bin/start-%(ENV_START_MODE)s.sh
-stdout_logfile=syslog
-stderr_logfile=syslog
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+redirect_stderr=true
 autostart=true
 autorestart=unexpected
 stopasgroup=true


### PR DESCRIPTION
Changed default template to log levels in messages
Disables duplicate message logging
Combination of stderr and stdout streams will show up on stdout
